### PR TITLE
Update to Zig master

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-*zig-cache
+*zig-*
+.direnv

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "mach"]
 	path = mach
-	url = git@github.com:jamii/mach.git
+	url = git@github:hexops/mach.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "mach"]
 	path = mach
-	url = git@github:hexops/mach.git
+	url = git@github.com:hexops/mach.git

--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@ A low-latency text editor.
 Not intended ot be useful for anyone but me, but perhaps a useful starting point to fork off your own editor.
 
 ``` sh
-nix develop
+nix-shell
 zig build run -Doptimize=ReleaseSafe -Dhome-path=/home/jamie -Dprojects-file-path=/home/jamie/secret/projects
 ```

--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@ A low-latency text editor.
 
 Probably not useful for anyone but me, but perhaps a useful starting point to fork off your own editor.
 
-Unlikely to build out of the box on anything that isn't my laptop. But as a starting point:
+To build focus, you'll need `GL`, `X11` development libraries and Zig 0.11.x compiler.
 
+Nix is configured to setup the correct development environment.
+
+Run these commands to build focus:
 ```
-nix-shell
-zig build run -Drelease-safe=true
+$ nix develop # or nix-shell
+$ zig build run -Drelease-safe=true
 ```
 
 See the architecture notes [here](https://scattered-thoughts.net/#focus).

--- a/README.md
+++ b/README.md
@@ -1,15 +1,8 @@
 A low-latency text editor.
 
-Probably not useful for anyone but me, but perhaps a useful starting point to fork off your own editor.
+Not intended ot be useful for anyone but me, but perhaps a useful starting point to fork off your own editor.
 
-To build focus, you'll need `GL`, `X11` development libraries and Zig 0.11.x compiler.
-
-Nix is configured to setup the correct development environment.
-
-Run these commands to build focus:
+``` sh
+nix develop
+zig build run -Doptimize=ReleaseSafe -Dhome-path=/home/jamie -Dprojects-file-path=/home/jamie/secret/projects
 ```
-$ nix develop # or nix-shell
-$ zig build run -Drelease-safe=true
-```
-
-See the architecture notes [here](https://scattered-thoughts.net/#focus).

--- a/bin/focus.zig
+++ b/bin/focus.zig
@@ -51,7 +51,7 @@ pub fn main() void {
         .Request => |request| {
             // if we successfully bound the socket then we need to create the daemon
             if (server_socket.state == .Bound) {
-                const log_filename = focus.util.format(arena.allocator(), "/home/jamie/.log/{s}.log", .{std.fs.path.basename(args[0])});
+                const log_filename = focus.util.format(arena.allocator(), "/tmp/{s}.log", .{std.fs.path.basename(args[0])});
                 if (focus.daemonize(log_filename) == .Child) {
                     focus.run(allocator, server_socket);
                     // run doesn't return

--- a/build.zig
+++ b/build.zig
@@ -9,47 +9,32 @@ pub fn build(b: *Builder) !void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
 
-    const home_path = std.os.getenv("HOME") orelse @panic("HOME environment variable is not defined");
-    const focus_state_dir = fsd: {
-        var focus_state_dir_path: ?[]const u8 = null;
-        // $XDG_STATE_HOME defines the base directory relative to which user-specific state files should be stored
-        if (std.os.getenv("XDG_STATE_HOME")) |xdg_state_home| {
-            if (xdg_state_home.len != 0) {
-                focus_state_dir_path = try std.fmt.allocPrint(b.allocator, "{s}/focus", .{xdg_state_home});
-            }
-        }
-        // If $XDG_STATE_HOME is either not set or empty, a default equal to $HOME/.local/state should be used
-        if (focus_state_dir_path == null) {
-            focus_state_dir_path = try std.fmt.allocPrint(b.allocator, "{s}/.local/state/focus", .{home_path});
-        }
-        break :fsd try std.fs.cwd().makeOpenPath(focus_state_dir_path.?, .{});
-    };
-    const projects_file_path = pfp: {
-        const projects_file_path = try std.fmt.allocPrint(b.allocator, "{s}/projects", .{try focus_state_dir.realpathAlloc(b.allocator, ".")});
-        var projects_file = focus_state_dir.createFile(projects_file_path, .{.truncate = false, .exclusive = true}) catch |err| switch (err) {
-            error.PathAlreadyExists => {
-                break :pfp projects_file_path;
-            },
-            else => return err,
-        };
-        _ = try projects_file.write(try std.fs.cwd().realpathAlloc(b.allocator, "."));
-        projects_file.close();
-        break :pfp projects_file_path;
-    };
-    const focus_exe = b.addExecutable(.{
-        .name = "focus",
+    const config = b.addOptions();
+    config.addOption(
+        []const u8,
+        "home_path",
+        b.option([]const u8, "home-path", "") orelse "/home/jamie",
+    );
+    config.addOption(
+        []const u8,
+        "projects_file_path",
+        b.option([]const u8, "projects-file-path", "") orelse "/home/jamie/secret/projects",
+    );
+
+    const exe = b.addExecutable(.{
+        .name = "focus-dev",
         .root_source_file = .{ .path = "./bin/focus.zig" },
         .target = target,
         .optimize = optimize,
     });
-    focus_exe.setMainPkgPath("./");
-    focus_exe.linkLibC();
-    focus_exe.linkSystemLibrary("GL");
-    focus_exe.setOutputDir("./zig-cache");
-    focus_exe.addModule("freetype", freetype.module(b));
-    freetype.link(b, focus_exe, .{});
-    focus_exe.addModule("glfw", glfw.module(b));
-    try glfw.link(b, focus_exe, .{
+    exe.setMainPkgPath("./");
+    exe.linkLibC();
+    exe.linkSystemLibrary("GL");
+    exe.setOutputDir("./zig-cache");
+    exe.addModule("freetype", freetype.module(b));
+    freetype.link(b, exe, .{});
+    exe.addModule("glfw", glfw.module(b));
+    try glfw.link(b, exe, .{
         .vulkan = false,
         .metal = false,
         .opengl = true,
@@ -60,17 +45,14 @@ pub fn build(b: *Builder) !void {
         .wayland = false,
         .system_sdk = .{},
     });
-    focus_exe.omit_frame_pointer = false;
-    const focus_paths = b.addOptions();
-    focus_paths.addOption([]const u8, "home_path", home_path);
-    focus_paths.addOption([]const u8, "projects_file_path", projects_file_path);
-    focus_exe.addOptions("focus_paths", focus_paths);
-    focus_exe.install();
+    exe.omit_frame_pointer = false;
+    exe.addOptions("focus_config", config);
+    exe.install();
 
-    const focus_exe_step = b.step("focus", "build your Minimalist text editor");
-    focus_exe_step.dependOn(&focus_exe.step);
+    const exe_step = b.step("build", "Build");
+    exe_step.dependOn(&exe.step);
 
-    const run = focus_exe.run();
-    const run_step = b.step("run", "Run focus");
+    const run = exe.run();
+    const run_step = b.step("run", "Run");
     run_step.dependOn(&run.step);
 }

--- a/build.zig
+++ b/build.zig
@@ -9,6 +9,33 @@ pub fn build(b: *Builder) !void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
 
+    const home_path = std.os.getenv("HOME") orelse @panic("HOME environment variable is not defined");
+    const focus_state_dir = fsd: {
+        var focus_state_dir_path: ?[]const u8 = null;
+        // $XDG_STATE_HOME defines the base directory relative to which user-specific state files should be stored
+        if (std.os.getenv("XDG_STATE_HOME")) |xdg_state_home| {
+            if (xdg_state_home.len != 0) {
+                focus_state_dir_path = try std.fmt.allocPrint(b.allocator, "{s}/focus", .{xdg_state_home});
+            }
+        }
+        // If $XDG_STATE_HOME is either not set or empty, a default equal to $HOME/.local/state should be used
+        if (focus_state_dir_path == null) {
+            focus_state_dir_path = try std.fmt.allocPrint(b.allocator, "{s}/.local/state/focus", .{home_path});
+        }
+        break :fsd try std.fs.cwd().makeOpenPath(focus_state_dir_path.?, .{});
+    };
+    const projects_file_path = pfp: {
+        const projects_file_path = try std.fmt.allocPrint(b.allocator, "{s}/projects", .{try focus_state_dir.realpathAlloc(b.allocator, ".")});
+        var projects_file = focus_state_dir.createFile(projects_file_path, .{.truncate = false, .exclusive = true}) catch |err| switch (err) {
+            error.PathAlreadyExists => {
+                break :pfp projects_file_path;
+            },
+            else => return err,
+        };
+        _ = try projects_file.write(try std.fs.cwd().realpathAlloc(b.allocator, "."));
+        projects_file.close();
+        break :pfp projects_file_path;
+    };
     const focus_exe = b.addExecutable(.{
         .name = "focus",
         .root_source_file = .{ .path = "./bin/focus.zig" },
@@ -34,6 +61,10 @@ pub fn build(b: *Builder) !void {
         .system_sdk = .{},
     });
     focus_exe.omit_frame_pointer = false;
+    const focus_paths = b.addOptions();
+    focus_paths.addOption([]const u8, "home_path", home_path);
+    focus_paths.addOption([]const u8, "projects_file_path", projects_file_path);
+    focus_exe.addOptions("focus_paths", focus_paths);
     focus_exe.install();
 
     const focus_exe_step = b.step("focus", "build your Minimalist text editor");

--- a/build.zig
+++ b/build.zig
@@ -38,7 +38,7 @@ pub fn build(b: *Builder) !void {
 
 fn includeCommon(b: *Builder, exe: *std.build.LibExeObjStep) !void {
     exe.setMainPkgPath("./");
-    exe.linkSystemLibrary("c");
+    exe.linkLibC();
     exe.linkSystemLibrary("GL");
     exe.setOutputDir("./zig-cache");
     exe.addPackage(freetype.pkg);

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,145 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "mach": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1679264116,
+        "narHash": "sha256-2HDLR09KFzi7H4KkIrOiorp7evHOdVxL+sN+cFzmPdI=",
+        "owner": "hexops",
+        "repo": "mach",
+        "rev": "624ab118dbf431a267ec6a9b7644be5bb586489f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hexops",
+        "repo": "mach",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1672580127,
+        "narHash": "sha256-3lW3xZslREhJogoOkjeZtlBtvFMyxHku7I/9IVehhT8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "0874168639713f547c05947c76124f78441ea46c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "release-22.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1661151577,
+        "narHash": "sha256-++S0TuJtuz9IpqP8rKktWyHZKpgdyrzDFUXVY07MTRI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "54060e816971276da05970a983487a25810c38a7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "mach": "mach",
+        "nixpkgs": "nixpkgs",
+        "zig": "zig"
+      }
+    },
+    "zig": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1679400494,
+        "narHash": "sha256-eobo+zGljkuMVrXAcwUhc4ENp/PgMXs6HObBs66Uhhc=",
+        "owner": "mitchellh",
+        "repo": "zig-overlay",
+        "rev": "10db68c9ddccb420b1222c6dafcabd232d719a83",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mitchellh",
+        "repo": "zig-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -62,22 +62,6 @@
         "type": "github"
       }
     },
-    "mach": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1679264116,
-        "narHash": "sha256-2HDLR09KFzi7H4KkIrOiorp7evHOdVxL+sN+cFzmPdI=",
-        "owner": "hexops",
-        "repo": "mach",
-        "rev": "624ab118dbf431a267ec6a9b7644be5bb586489f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hexops",
-        "repo": "mach",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1672580127,
@@ -114,7 +98,6 @@
       "inputs": {
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
-        "mach": "mach",
         "nixpkgs": "nixpkgs",
         "zig": "zig"
       }
@@ -126,11 +109,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1679400494,
-        "narHash": "sha256-eobo+zGljkuMVrXAcwUhc4ENp/PgMXs6HObBs66Uhhc=",
+        "lastModified": 1679669017,
+        "narHash": "sha256-FUvrE/4HKsrl/CedvQuoJa+vDr9lM7elI28cJs9uSHs=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "10db68c9ddccb420b1222c6dafcabd232d719a83",
+        "rev": "810cecd27319cb79feb4a8e79ac7ad40c7826235",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,54 @@
+{
+  description = "An empty project that uses Zig.";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/release-22.05";
+    flake-utils.url = "github:numtide/flake-utils";
+    zig.url = "github:mitchellh/zig-overlay";
+
+    mach = {
+      url = github:hexops/mach;
+      flake = false;
+    };
+
+    # Used for shell.nix
+    flake-compat = {
+      url = github:edolstra/flake-compat;
+      flake = false;
+    };
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    ...
+  } @ inputs: let
+    overlays = [
+      # Other overlays
+      (final: prev: {
+        zigpkgs = inputs.zig.packages.${prev.system};
+      })
+    ];
+
+    # Our supported systems are the same supported systems as the Zig binaries
+    systems = builtins.attrNames inputs.zig.packages;
+  in
+    flake-utils.lib.eachSystem systems (
+      system: let
+        pkgs = import nixpkgs {inherit overlays system;};
+      in rec {
+        devShells.default = pkgs.mkShell {
+          addBuildRoots = [ inputs.mach ];
+          nativeBuildInputs = with pkgs; [
+            zigpkgs.master
+            libGL.all
+            xorg.libX11.dev
+          ];
+        };
+
+        # For compatibility with older versions of the `nix` binary
+        devShell = self.devShells.${system}.default;
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,7 @@
           ];
           shellHook = ''
             # Create symlinks in project root
-            # HACK: Symlink doesn't get deleted when `nix develop` shell is exitted
+            # HACK: Symlink doesn't get deleted when `nix develop` shell is exited
             # Zig stdlib - useful for browsing
             if [ ! -L ./zig-stdlib ]; then
               ln -s ${pkgs.zigpkg} ./zig-stdlib

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "An empty project that uses Zig.";
+  description = "Minimalist text editor written in Zig";
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/release-22.05";

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env bash
 
 nix-shell --run 'zig build local -Drelease-safe=true'
-pkill -9 focus-stable; sleep 1
-cp ./zig-cache/focus-local ~/bin/focus
+pkill -9 focus; sleep 1
+cp ./zig-cache/focus-dev ~/bin/focus

--- a/lib/focus.zig
+++ b/lib/focus.zig
@@ -1,4 +1,5 @@
 pub const util = @import("./focus/util.zig");
+pub const config = @import("focus_config");
 pub const Atlas = @import("./focus/atlas.zig").Atlas;
 pub const Buffer = @import("./focus/buffer.zig").Buffer;
 pub const LineWrappedBuffer = @import("./focus/line_wrapped_buffer.zig").LineWrappedBuffer;
@@ -23,7 +24,6 @@ const std = @import("std");
 const glfw = @import("glfw");
 const u = util;
 const c = util.c;
-const focus_paths = @import("focus_paths");
 
 pub const Request = union(enum) {
     CreateEmptyWindow,
@@ -72,7 +72,7 @@ pub fn daemonize(log_filename: []const u8) enum { Parent, Child } {
     } else |err| {
         u.panic("Failed to fork: {}", .{err});
     }
-    if (std.os.linux.chdir(@ptrCast([*:0]const u8, focus_paths.home_path)) < 0)
+    if (std.os.linux.chdir(@ptrCast([*:0]const u8, config.home_path)) < 0)
         u.panic("Failed to chdir", .{});
 
     // redirect stdout/err to log

--- a/lib/focus.zig
+++ b/lib/focus.zig
@@ -23,6 +23,7 @@ const std = @import("std");
 const glfw = @import("glfw");
 const u = util;
 const c = util.c;
+const focus_paths = @import("focus_paths");
 
 pub const Request = union(enum) {
     CreateEmptyWindow,
@@ -71,7 +72,7 @@ pub fn daemonize(log_filename: []const u8) enum { Parent, Child } {
     } else |err| {
         u.panic("Failed to fork: {}", .{err});
     }
-    if (std.os.linux.chdir("/home/jamie/") < 0)
+    if (std.os.linux.chdir(@ptrCast([*:0]const u8, focus_paths.home_path)) < 0)
         u.panic("Failed to chdir", .{});
 
     // redirect stdout/err to log

--- a/lib/focus/atlas.zig
+++ b/lib/focus/atlas.zig
@@ -23,7 +23,7 @@ pub const Atlas = struct {
         defer lib.deinit();
 
         // load font
-        const face = lib.newFaceMemory(fira_code, 0) catch |err|
+        const face = lib.createFaceMemory(fira_code, 0) catch |err|
             u.panic("Error loading font: {}", .{err});
         defer face.deinit();
 
@@ -95,7 +95,7 @@ pub const Atlas = struct {
         const texture = allocator.alloc(u.Color, num_chars * @intCast(usize, char_width * char_height)) catch u.oom();
         for (texture) |*pixel| pixel.* = .{ .r = 0, .g = 0, .b = 0, .a = 0 };
         const char_to_rect = allocator.alloc(u.Rect, num_chars) catch u.oom();
-        for (char_to_bitmap) |bitmap, char| {
+        for (char_to_bitmap, 0..) |bitmap, char| {
             const cbox = char_to_cbox[char];
 
             const bitmap_width = cbox.xMax - cbox.xMin;

--- a/lib/focus/buffer.zig
+++ b/lib/focus/buffer.zig
@@ -185,7 +185,7 @@ pub const Buffer = struct {
             }
             self.source.File.mtime = result.mtime;
         } else |err| {
-            const message = u.format(self.app.frame_allocator, "{} while loading {s}", .{ err, self.getFilename() });
+            const message = u.format(self.app.frame_allocator, "{} while loading {s}", .{ err, self.getFilename() orelse "<buffer>" });
             std.debug.print("{s}\n", .{message});
             self.replace(message);
         }
@@ -431,7 +431,7 @@ pub const Buffer = struct {
 
     pub fn newUndoGroup(self: *Buffer) void {
         if (self.doing.items.len > 0) {
-            const edits = self.doing.toOwnedSlice();
+            const edits = self.doing.toOwnedSlice() catch u.oom();
             std.mem.reverse(Edit, edits);
             self.undos.append(edits) catch u.oom();
         }
@@ -574,7 +574,8 @@ pub const Buffer = struct {
     pub fn getCompletionRange(self: *Buffer, pos: usize) [2]usize {
         return if (self.language.getTokenIxBefore(pos)) |token_ix|
             self.language.getTokenRanges()[token_ix]
-        else .{ pos, pos };
+        else
+            .{ pos, pos };
     }
 
     pub fn getCompletionPrefix(self: *Buffer, pos: usize) []const u8 {

--- a/lib/focus/buffer_searcher.zig
+++ b/lib/focus/buffer_searcher.zig
@@ -85,9 +85,7 @@ pub const BufferSearcher = struct {
                     result.appendNTimes(' ', max_line_string.len - line_string.len + 1) catch u.oom();
                     result.appendSlice(selection) catch u.oom();
 
-                    results.append(
-                            result.toOwnedSlice() catch u.oom()
-                        ) catch u.oom();
+                    results.append(result.toOwnedSlice() catch u.oom()) catch u.oom();
                     result_poss.append(found_pos) catch u.oom();
 
                     pos = found_pos + filter.len;

--- a/lib/focus/buffer_searcher.zig
+++ b/lib/focus/buffer_searcher.zig
@@ -85,7 +85,9 @@ pub const BufferSearcher = struct {
                     result.appendNTimes(' ', max_line_string.len - line_string.len + 1) catch u.oom();
                     result.appendSlice(selection) catch u.oom();
 
-                    results.append(result.toOwnedSlice()) catch u.oom();
+                    results.append(
+                            result.toOwnedSlice() catch u.oom()
+                        ) catch u.oom();
                     result_poss.append(found_pos) catch u.oom();
 
                     pos = found_pos + filter.len;
@@ -96,7 +98,7 @@ pub const BufferSearcher = struct {
 
         // update selection
         self.selector.selected = u.max(result_poss.items.len, 1) - 1;
-        for (result_poss.items) |result_pos, i| {
+        for (result_poss.items, 0..) |result_pos, i| {
             if (self.selection_pos < result_pos + filter.len) {
                 self.selector.selected = i;
                 break;
@@ -145,7 +147,7 @@ pub const BufferSearcher = struct {
                 }
             },
             .SelectAll => {
-                for (result_poss) |pos, i| {
+                for (result_poss, 0..) |pos, i| {
                     var cursor = if (i == 0) editor.getMainCursor() else editor.newCursor();
                     editor.goPos(cursor, pos + filter.len);
                     editor.updatePos(&cursor.tail, pos);

--- a/lib/focus/child_process.zig
+++ b/lib/focus/child_process.zig
@@ -26,15 +26,15 @@ pub const ChildProcess = struct {
     }
 
     pub fn deinit(self: *ChildProcess) void {
-        const pgid = std.os.linux.syscall1(.getpgid, @bitCast(usize, @as(isize, self.child_process.pid)));
+        const pgid = std.os.linux.syscall1(.getpgid, @bitCast(usize, @as(isize, self.child_process.id)));
         std.os.kill(-@intCast(i32, pgid), std.os.SIG.KILL) catch {};
         self.child_process.stdout.?.close();
         self.child_process.stderr.?.close();
     }
 
     pub fn poll(self: ChildProcess) enum { Running, Finished } {
-        const wait = std.os.waitpid(self.child_process.pid, std.os.linux.WNOHANG);
-        return if (wait.pid == self.child_process.pid) .Finished else .Running;
+        const wait = std.os.waitpid(self.child_process.id, std.os.linux.WNOHANG);
+        return if (wait.id == self.child_process.id) .Finished else .Running;
     }
 
     pub fn read(self: ChildProcess, allocator: u.Allocator) []const u8 {
@@ -58,6 +58,6 @@ pub const ChildProcess = struct {
             }
         }
         bytes.shrinkAndFree(start);
-        return bytes.toOwnedSlice();
+        return bytes.toOwnedSlice() catch u.oom();
     }
 };

--- a/lib/focus/editor.zig
+++ b/lib/focus/editor.zig
@@ -3,7 +3,6 @@ const glfw = @import("glfw");
 const focus = @import("../focus.zig");
 const u = focus.util;
 const c = focus.util.c;
-const focus_paths = @import("focus_paths");
 const App = focus.App;
 const Buffer = focus.Buffer;
 const LineWrappedBuffer = focus.LineWrappedBuffer;
@@ -188,7 +187,7 @@ pub const Editor = struct {
                                 window.pushView(buffer_searcher);
                             },
                             .g => {
-                                const project_dir = self.buffer.getProjectDir() orelse focus_paths.projects_file_path;
+                                const project_dir = self.buffer.getProjectDir() orelse focus.config.projects_file_path;
                                 if (self.buffer.language.getIdentifierRangeAt(self.getMainCursor().head.pos)) |identifier_range| {
                                     const identifier = self.buffer.bytes.items[identifier_range[0]..identifier_range[1]];
                                     var filter = u.ArrayList(u8).init(self.app.frame_allocator);
@@ -233,7 +232,7 @@ pub const Editor = struct {
                             },
                             .slash => for (self.cursors.items) |*cursor| self.modifyComment(cursor, .Remove),
                             .g => {
-                                const project_dir = self.buffer.getProjectDir() orelse focus_paths.projects_file_path;
+                                const project_dir = self.buffer.getProjectDir() orelse focus.config.projects_file_path;
                                 if (self.buffer.language.getIdentifierRangeAt(self.getMainCursor().head.pos)) |identifier_range| {
                                     const identifier = self.buffer.bytes.items[identifier_range[0]..identifier_range[1]];
                                     var filter = u.ArrayList(u8).init(self.app.frame_allocator);

--- a/lib/focus/editor.zig
+++ b/lib/focus/editor.zig
@@ -3,6 +3,7 @@ const glfw = @import("glfw");
 const focus = @import("../focus.zig");
 const u = focus.util;
 const c = focus.util.c;
+const focus_paths = @import("focus_paths");
 const App = focus.App;
 const Buffer = focus.Buffer;
 const LineWrappedBuffer = focus.LineWrappedBuffer;
@@ -187,7 +188,7 @@ pub const Editor = struct {
                                 window.pushView(buffer_searcher);
                             },
                             .g => {
-                                const project_dir = self.buffer.getProjectDir() orelse "/home/jamie";
+                                const project_dir = self.buffer.getProjectDir() orelse focus_paths.projects_file_path;
                                 if (self.buffer.language.getIdentifierRangeAt(self.getMainCursor().head.pos)) |identifier_range| {
                                     const identifier = self.buffer.bytes.items[identifier_range[0]..identifier_range[1]];
                                     var filter = u.ArrayList(u8).init(self.app.frame_allocator);
@@ -232,7 +233,7 @@ pub const Editor = struct {
                             },
                             .slash => for (self.cursors.items) |*cursor| self.modifyComment(cursor, .Remove),
                             .g => {
-                                const project_dir = self.buffer.getProjectDir() orelse "/home/jamie";
+                                const project_dir = self.buffer.getProjectDir() orelse focus_paths.projects_file_path;
                                 if (self.buffer.language.getIdentifierRangeAt(self.getMainCursor().head.pos)) |identifier_range| {
                                     const identifier = self.buffer.bytes.items[identifier_range[0]..identifier_range[1]];
                                     var filter = u.ArrayList(u8).init(self.app.frame_allocator);

--- a/lib/focus/language.zig
+++ b/lib/focus/language.zig
@@ -144,7 +144,7 @@ pub const Language = union(enum) {
     pub fn getTokenIxBefore(self: Language, pos: usize) ?usize {
         const token_ranges = self.getTokenRanges();
         var return_ix: ?usize = null;
-        for (token_ranges) |token_range, ix| {
+        for (token_ranges, 0..) |token_range, ix| {
             if (token_range[0] >= pos) break;
             return_ix = ix;
         }
@@ -153,7 +153,7 @@ pub const Language = union(enum) {
 
     pub fn getTokenIxAfter(self: Language, pos: usize) ?usize {
         const token_ranges = self.getTokenRanges();
-        for (token_ranges) |token_range, ix| {
+        for (token_ranges, 0..) |token_range, ix| {
             if (token_range[0] >= pos)
                 return ix;
         }
@@ -199,7 +199,7 @@ pub const Language = union(enum) {
                 i += 1;
             }
         }
-        return new_source.toOwnedSlice();
+        return new_source.toOwnedSlice() catch u.oom();
     }
 
     pub fn matchParen(self: Language, pos: usize) ?usize {

--- a/lib/focus/language/clojure.zig
+++ b/lib/focus/language/clojure.zig
@@ -37,7 +37,7 @@ pub const State = struct {
         const paren_matches = allocator.alloc(?usize, tokens.items.len) catch u.oom();
         std.mem.set(?usize, paren_matches, null);
         var paren_match_stack = u.ArrayList(usize).init(allocator);
-        for (tokens.items) |token, ix| {
+        for (tokens.items, 0..) |token, ix| {
             switch (token) {
                 .close_list, .close_vec, .close_map => {
                     if (paren_match_stack.popOrNull()) |matching_ix| {
@@ -60,8 +60,8 @@ pub const State = struct {
 
         return .{
             .allocator = allocator,
-            .tokens = tokens.toOwnedSlice(),
-            .token_ranges = token_ranges.toOwnedSlice(),
+            .tokens = tokens.toOwnedSlice() catch u.oom(),
+            .token_ranges = token_ranges.toOwnedSlice() catch u.oom(),
             .paren_levels = paren_levels,
             .paren_parents = paren_parents,
             .paren_matches = paren_matches,
@@ -102,7 +102,7 @@ pub const State = struct {
 
     pub fn highlight(self: State, source: []const u8, range: [2]usize, colors: []u.Color) void {
         std.mem.set(u.Color, colors, style.comment_color);
-        for (self.token_ranges) |token_range, i| {
+        for (self.token_ranges, 0..) |token_range, i| {
             const source_start = token_range[0];
             const source_end = token_range[1];
             if (source_end < range[0] or source_start > range[1]) continue;

--- a/lib/focus/language/generic.zig
+++ b/lib/focus/language/generic.zig
@@ -38,7 +38,7 @@ pub const State = struct {
         const paren_matches = allocator.alloc(?usize, tokens.items.len) catch u.oom();
         std.mem.set(?usize, paren_matches, null);
         var paren_match_stack = u.ArrayList(usize).init(allocator);
-        for (tokens.items) |token, ix| {
+        for (tokens.items, 0..) |token, ix| {
             switch (token) {
                 .close_paren, .close_bracket, .close_brace => {
                     if (paren_match_stack.popOrNull()) |matching_ix| {
@@ -62,8 +62,8 @@ pub const State = struct {
         return .{
             .allocator = allocator,
             .comment_string = comment_string,
-            .tokens = tokens.toOwnedSlice(),
-            .token_ranges = token_ranges.toOwnedSlice(),
+            .tokens = tokens.toOwnedSlice() catch u.oom(),
+            .token_ranges = token_ranges.toOwnedSlice() catch u.oom(),
             .paren_levels = paren_levels,
             .paren_parents = paren_parents,
             .paren_matches = paren_matches,
@@ -105,7 +105,7 @@ pub const State = struct {
 
     pub fn highlight(self: State, source: []const u8, range: [2]usize, colors: []u.Color) void {
         std.mem.set(u.Color, colors, style.comment_color);
-        for (self.token_ranges) |token_range, i| {
+        for (self.token_ranges, 0..) |token_range, i| {
             const source_start = token_range[0];
             const source_end = token_range[1];
             if (source_end < range[0] or source_start > range[1]) continue;

--- a/lib/focus/launcher.zig
+++ b/lib/focus/launcher.zig
@@ -2,7 +2,6 @@ const std = @import("std");
 const focus = @import("../focus.zig");
 const u = focus.util;
 const c = focus.util.c;
-const focus_paths = @import("focus_paths");
 const App = focus.App;
 const Buffer = focus.Buffer;
 const Editor = focus.Editor;
@@ -27,7 +26,7 @@ pub const Launcher = struct {
             const result = std.ChildProcess.exec(.{
                 .allocator = app.frame_allocator,
                 .argv = &[_][]const u8{ "fish", "-C", "complete -C ''" },
-                .cwd = focus_paths.home_path,
+                .cwd = focus.config.home_path,
                 .max_output_bytes = 128 * 1024 * 1024,
             }) catch |err| u.panic("{} while calling compgen", .{err});
             u.assert(result.term == .Exited and result.term.Exited == 0);

--- a/lib/focus/launcher.zig
+++ b/lib/focus/launcher.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const focus = @import("../focus.zig");
 const u = focus.util;
 const c = focus.util.c;
+const focus_paths = @import("focus_paths");
 const App = focus.App;
 const Buffer = focus.Buffer;
 const Editor = focus.Editor;
@@ -26,7 +27,7 @@ pub const Launcher = struct {
             const result = std.ChildProcess.exec(.{
                 .allocator = app.frame_allocator,
                 .argv = &[_][]const u8{ "fish", "-C", "complete -C ''" },
-                .cwd = "/home/jamie",
+                .cwd = focus_paths.home_path,
                 .max_output_bytes = 128 * 1024 * 1024,
             }) catch |err| u.panic("{} while calling compgen", .{err});
             u.assert(result.term == .Exited and result.term.Exited == 0);

--- a/lib/focus/launcher.zig
+++ b/lib/focus/launcher.zig
@@ -32,7 +32,8 @@ pub const Launcher = struct {
             u.assert(result.term == .Exited and result.term.Exited == 0);
             var lines = std.mem.split(u8, result.stdout, "\n");
             while (lines.next()) |line| {
-                const command = std.mem.split(u8, line, "\t").next().?;
+                var it = std.mem.split(u8, line, "\t");
+                const command = it.first();
                 exes.append(app.dupe(command)) catch u.oom();
             }
         }
@@ -42,7 +43,7 @@ pub const Launcher = struct {
             .app = app,
             .input = input,
             .selector = selector,
-            .exes = exes.toOwnedSlice(),
+            .exes = exes.toOwnedSlice() catch u.oom(),
         };
         return self;
     }

--- a/lib/focus/mach_compat.zig
+++ b/lib/focus/mach_compat.zig
@@ -67,8 +67,7 @@ fn mouseMotionCallback(window: glfw.Window, xpos: f64, ypos: f64) void {
 
 fn mouseButtonCallback(window: glfw.Window, button: glfw.mouse_button.MouseButton, action: glfw.Action, mods: glfw.Mods) void {
     const events = window.getUserPointer(u.ArrayList(Event)) orelse unreachable;
-    const cursor_pos = window.getCursorPos() catch |err|
-        u.panic("Error getting cursor pos: {}", .{err});
+    const cursor_pos = window.getCursorPos();
     const mouse_button_event = MouseButtonEvent{
         .button = button,
         .pos = cursor_pos,

--- a/lib/focus/maker.zig
+++ b/lib/focus/maker.zig
@@ -57,13 +57,13 @@ pub const Maker = struct {
             .show_status_bar = false,
             .show_completer = false,
         });
-        const input = SingleLineEditor.init(app, "/home/jamie/");
+        const input = SingleLineEditor.init(app, focus.config.home_path);
         const selector = Selector.init(app);
 
         const result = std.ChildProcess.exec(.{
             .allocator = app.frame_allocator,
             .argv = &[_][]const u8{ "fish", "--command", "history" },
-            .cwd = "/home/jamie",
+            .cwd = focus.config.home_path,
             .max_output_bytes = 128 * 1024 * 1024,
         }) catch |err| u.panic("{} while calling fish history", .{err});
         u.assert(result.term == .Exited and result.term.Exited == 0);
@@ -175,7 +175,12 @@ pub const Maker = struct {
 
                 if (command_o) |command| {
                     // add command to history
-                    const history_file = std.fs.cwd().openFile("/home/jamie/.local/share/fish/fish_history", .{ .mode = .write_only }) catch |err|
+                    const history_path = std.fmt.allocPrint(
+                        self.app.frame_allocator,
+                        "{s}/.local/share/fish/fish_history",
+                        .{focus.config.home_path},
+                    ) catch u.oom();
+                    const history_file = std.fs.cwd().openFile(history_path, .{ .mode = .write_only }) catch |err|
                         u.panic("Failed to open fish history: {}", .{err});
                     history_file.seekFromEnd(0) catch |err|
                         u.panic("Failed to seek to end of fish history: {}", .{err});

--- a/lib/focus/maker.zig
+++ b/lib/focus/maker.zig
@@ -81,7 +81,7 @@ pub const Maker = struct {
             .selector = selector,
             .result_editor = result_editor,
             .history_string = history_string,
-            .history = history.toOwnedSlice(),
+            .history = history.toOwnedSlice() catch u.oom(),
             .state = .ChoosingDir,
         };
         return self;

--- a/lib/focus/project_file_opener.zig
+++ b/lib/focus/project_file_opener.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const focus = @import("../focus.zig");
 const u = focus.util;
 const c = focus.util.c;
+const focus_paths = @import("focus_paths");
 const App = focus.App;
 const Buffer = focus.Buffer;
 const Editor = focus.Editor;
@@ -37,11 +38,11 @@ pub const ProjectFileOpener = struct {
 
         var projects = u.ArrayList(u8).init(app.frame_allocator);
         {
-            const file = std.fs.cwd().openFile("/home/jamie/secret/projects", .{}) catch |err|
-                u.panic("{} while opening /home/jamie/secret/projects", .{err});
+            const file = std.fs.cwd().openFile(focus_paths.projects_file_path, .{}) catch |err|
+                u.panic("{} while opening {s}", .{err, focus_paths.projects_file_path});
             defer file.close();
             file.reader().readAllArrayList(&projects, std.math.maxInt(usize)) catch |err|
-                u.panic("{} while reading /home/jamie/secret/projects", .{err});
+                u.panic("{} while reading {s}", .{err, focus_paths.projects_file_path});
         }
 
         var paths = u.ArrayList([]const u8).init(app.allocator);

--- a/lib/focus/project_file_opener.zig
+++ b/lib/focus/project_file_opener.zig
@@ -76,7 +76,7 @@ pub const ProjectFileOpener = struct {
             .preview_editor = preview_editor,
             .input = input,
             .selector = selector,
-            .paths = paths.toOwnedSlice(),
+            .paths = paths.toOwnedSlice() catch u.oom(),
         };
         return self;
     }

--- a/lib/focus/project_file_opener.zig
+++ b/lib/focus/project_file_opener.zig
@@ -2,7 +2,6 @@ const std = @import("std");
 const focus = @import("../focus.zig");
 const u = focus.util;
 const c = focus.util.c;
-const focus_paths = @import("focus_paths");
 const App = focus.App;
 const Buffer = focus.Buffer;
 const Editor = focus.Editor;
@@ -38,11 +37,11 @@ pub const ProjectFileOpener = struct {
 
         var projects = u.ArrayList(u8).init(app.frame_allocator);
         {
-            const file = std.fs.cwd().openFile(focus_paths.projects_file_path, .{}) catch |err|
-                u.panic("{} while opening {s}", .{err, focus_paths.projects_file_path});
+            const file = std.fs.cwd().openFile(focus.config.projects_file_path, .{}) catch |err|
+                u.panic("{} while opening {s}", .{ err, focus.config.projects_file_path });
             defer file.close();
             file.reader().readAllArrayList(&projects, std.math.maxInt(usize)) catch |err|
-                u.panic("{} while reading {s}", .{err, focus_paths.projects_file_path});
+                u.panic("{} while reading {s}", .{ err, focus.config.projects_file_path });
         }
 
         var paths = u.ArrayList([]const u8).init(app.allocator);

--- a/lib/focus/project_searcher.zig
+++ b/lib/focus/project_searcher.zig
@@ -121,7 +121,7 @@ pub const ProjectSearcher = struct {
                         result_ranges.append(.{ start, end }) catch u.oom();
                     start = end + 1;
                 }
-                self.selector.setRanges(result_ranges.toOwnedSlice());
+                self.selector.setRanges(result_ranges.toOwnedSlice() catch u.oom());
             }
         }
 

--- a/lib/focus/selector.zig
+++ b/lib/focus/selector.zig
@@ -56,7 +56,7 @@ pub const Selector = struct {
             text.append('\n') catch u.oom();
             ranges.append(.{ start, end }) catch u.oom();
         }
-        self.setTextAndRanges(text.toOwnedSlice(), ranges.toOwnedSlice());
+        self.setTextAndRanges(text.toOwnedSlice() catch u.oom(), ranges.toOwnedSlice() catch u.oom());
     }
 
     pub fn setTextAndRanges(self: *Selector, text: []const u8, ranges: []const [2]usize) void {

--- a/lib/focus/style.zig
+++ b/lib/focus/style.zig
@@ -14,7 +14,7 @@ pub const multi_cursor_color = u.Color.hsla(150, 1.0, 0.5, 1.0);
 pub const paren_match_color = u.Color.hsla(150, 1.0, 0.5, 0.3);
 
 pub fn identColor(ident: []const u8) u.Color {
-    const hash = @bitReverse(u64, u.deepHash(ident));
+    const hash = @bitReverse(u.deepHash(ident));
     return u.Color.hsla(
         @intToFloat(f64, hash % 359),
         1.0,
@@ -24,7 +24,7 @@ pub fn identColor(ident: []const u8) u.Color {
 }
 
 pub fn parenColor(level: usize) u.Color {
-    const hash = @bitReverse(u64, u.deepHash(level));
+    const hash = @bitReverse(u.deepHash(level));
     return u.Color.hsla(
         @intToFloat(f64, hash % 359),
         1.0,

--- a/lib/focus/util.zig
+++ b/lib/focus/util.zig
@@ -28,7 +28,11 @@ pub fn panic(comptime fmt: []const u8, args: anytype) noreturn {
                 error.OutOfMemory => break :message "OOM inside panic",
             }
         };
-        break :message buf.toOwnedSlice();
+        break :message buf.toOwnedSlice() catch |err| {
+            switch (err) {
+                error.OutOfMemory => break :message "OOM inside panic",
+            }
+        };
     };
     @panic(message);
 }
@@ -343,7 +347,7 @@ pub fn fuzzy_search(allocator: Allocator, items: []const []const u8, filter: []c
             var score: usize = std.math.maxInt(usize);
             var any_match = false;
             const filter_start_char = filter[0];
-            for (item) |start_char, start| {
+            for (item, 0..) |start_char, start| {
                 if (start_char == filter_start_char) {
                     var is_match = true;
                     var end = start;
@@ -377,7 +381,7 @@ pub fn fuzzy_search(allocator: Allocator, items: []const []const u8, filter: []c
     for (scored_items.items) |scored_item| {
         results.append(scored_item.item) catch oom();
     }
-    return results.toOwnedSlice();
+    return results.toOwnedSlice() catch oom();
 }
 
 pub fn fuzzy_search_paths(allocator: Allocator, path: []const u8) ![]const []const u8 {
@@ -395,7 +399,7 @@ pub fn fuzzy_search_paths(allocator: Allocator, path: []const u8) ![]const []con
             }
         }
         if (dirname_o) |dirname| {
-            var dir = try std.fs.cwd().openDir(dirname, .{ .iterate = true });
+            var dir = try std.fs.cwd().openIterableDir(dirname, .{});
             defer dir.close();
             var dir_iter = dir.iterate();
             while (dir_iter.next() catch |err| panic("{} while iterating dir {s}", .{ err, dirname })) |entry| {
@@ -403,7 +407,7 @@ pub fn fuzzy_search_paths(allocator: Allocator, path: []const u8) ![]const []con
                     var result = ArrayList(u8).init(allocator);
                     result.appendSlice(entry.name) catch oom();
                     if (entry.kind == .Directory) result.append('/') catch oom();
-                    results.append(result.toOwnedSlice()) catch oom();
+                    results.append(result.toOwnedSlice() catch oom()) catch oom();
                 }
             }
         }
@@ -413,7 +417,7 @@ pub fn fuzzy_search_paths(allocator: Allocator, path: []const u8) ![]const []con
             return std.mem.lessThan(u8, a, b);
         }
     }.lessThan);
-    return results.toOwnedSlice();
+    return results.toOwnedSlice() catch oom();
 }
 
 const Match = struct {
@@ -472,7 +476,7 @@ pub fn deepCompare(a: anytype, b: @TypeOf(a)) Ordering {
                     if (a.len > b.len) {
                         return .GreaterThan;
                     }
-                    for (a) |a_elem, a_ix| {
+                    for (a, 0..) |a_elem, a_ix| {
                         const ordering = deepCompare(a_elem, b[a_ix]);
                         if (ordering != .Equal) {
                             return ordering;
@@ -499,7 +503,7 @@ pub fn deepCompare(a: anytype, b: @TypeOf(a)) Ordering {
             }
         },
         .Array => {
-            for (a) |a_elem, a_ix| {
+            for (a, 0..) |a_elem, a_ix| {
                 const ordering = deepCompare(a_elem, b[a_ix]);
                 if (ordering != .Equal) {
                     return ordering;
@@ -579,7 +583,7 @@ pub fn deepHashInto(hasher: anytype, key: anytype) void {
         else => {},
     }
     switch (ti) {
-        .Int => @call(.{ .modifier = .always_inline }, hasher.update, .{std.mem.asBytes(&key)}),
+        .Int => @call(.always_inline, hasher.update, .{std.mem.asBytes(&key)}),
         .Float => |info| deepHashInto(hasher, @bitCast(std.Int(.unsigned, info.bits), key)),
         .Bool => deepHashInto(hasher, @boolToInt(key)),
         .Enum => deepHashInto(hasher, @enumToInt(key)),

--- a/lib/focus/util.zig
+++ b/lib/focus/util.zig
@@ -313,15 +313,6 @@ pub const Vec2f = packed struct {
     y: f32,
 };
 
-pub fn Tri(comptime t: type) type {
-    // TODO which direction?
-    return packed struct {
-        a: t,
-        b: t,
-        c: t,
-    };
-}
-
 pub fn Quad(comptime t: type) type {
     return packed struct {
         tl: t,

--- a/lib/focus/window.zig
+++ b/lib/focus/window.zig
@@ -203,7 +203,7 @@ pub const Window = struct {
                                     const init_path = if (self.getTopViewFilename()) |filename|
                                         std.mem.concat(self.app.frame_allocator, u8, &[_][]const u8{ std.fs.path.dirname(filename).?, "/" }) catch u.oom()
                                     else
-                                        "/home/jamie/";
+                                        focus.config.home_path;
                                     const file_opener = FileOpener.init(self.app, init_path);
                                     self.pushView(file_opener);
                                     handled = true;
@@ -247,7 +247,7 @@ pub const Window = struct {
                                         null;
                                     const project_searcher = ProjectSearcher.init(
                                         self.app,
-                                        project_dir orelse "/home/jamie",
+                                        project_dir orelse focus.config.home_path,
                                         .FixedStrings,
                                         null,
                                     );

--- a/lib/focus/window.zig
+++ b/lib/focus/window.zig
@@ -64,18 +64,18 @@ pub const Window = struct {
         const glfw_window = glfw_window: {
             const optional_glfw_window =
                 glfw.Window.create(
-                    init_width,
-                    init_height,
-                    "focus",
-                    null,
-                    null,
-                    .{
-                        .client_api = .opengl_api,
-                        .decorated = false,
-                        .floating = (floating == .Floating),
-                        // sway does not respect .floating but it will float non-resizable windows
-                        .resizable = (floating == .NotFloating),
-                    },
+                init_width,
+                init_height,
+                "focus",
+                null,
+                null,
+                .{
+                    .client_api = .opengl_api,
+                    .decorated = false,
+                    .floating = (floating == .Floating),
+                    // sway does not respect .floating but it will float non-resizable windows
+                    .resizable = (floating == .NotFloating),
+                },
             );
             if (optional_glfw_window) |window|
                 break :glfw_window window

--- a/shell.nix
+++ b/shell.nix
@@ -1,52 +1,12 @@
-{ cross ? false }:
-
-let
-
-  hostPkgs = import <nixpkgs> {};
-
-  armPkgs = import <nixpkgs> {
-    system = "aarch64-linux";
-  };
-
-  crossPkgs = import <nixpkgs> {
-    overlays = [(self: super: {
-      inherit (armPkgs)
-        gcc
-        mesa
-        libGL
-      ;
-    })];
-    crossSystem = hostPkgs.lib.systems.examples.aarch64-multiplatform;
-  };
-
-  targetPkgs = if cross then crossPkgs else hostPkgs;
-
-  zig = hostPkgs.stdenv.mkDerivation {
-        name = "zig";
-        src = fetchTarball (
-            if (targetPkgs.system == "x86_64-linux") then {
-                url = "https://ziglang.org/builds/zig-linux-x86_64-0.10.0-dev.2473+e498fb155.tar.xz";
-                sha256 = "1iih9wcr5v2k2v384ljv4nalfzgy0kbb0ilz7jdn5gh4h9jhy086";
-            } else
-            throw ("Unknown system " ++ targetPkgs.system)
-        );
-        dontConfigure = true;
-        dontBuild = true;
-        installPhase = ''
-            mkdir -p $out
-            mv ./* $out/
-            mkdir -p $out/bin
-            mv $out/zig $out/bin
-        '';
-    };
-
-in
-
-hostPkgs.mkShell rec {
-  buildInputs = [
-    zig
-    hostPkgs.git
-    targetPkgs.libGL.all
-    targetPkgs.xorg.libX11.dev
-  ];
-}
+(import
+  (
+    let
+      flake-compat = (builtins.fromJSON (builtins.readFile ./flake.lock)).nodes.flake-compat;
+    in
+      fetchTarball {
+        url = "https://github.com/edolstra/flake-compat/archive/${flake-compat.locked.rev}.tar.gz";
+        sha256 = flake-compat.locked.narHash;
+      }
+  )
+  {src = ./.;})
+.shellNix


### PR DESCRIPTION
Hi Jamie,

I wanted to ask whether you are still interested in maintaining this editor. Based on the commit history, it seems that you are not actively using it, but since it is not archived, I am hopeful that you may still be interested.

Changes:
1. Update the project to use nix flakes
This change helps people stay in-sync with the correct Zig version to build.
- Open a development shell in project root: 
```
$ nix develop
```
 (`$ nix-shell` should also work but I haven't tried that). This downloads Zig version specified in `flake.nix` and adds required development libraries into the environment.
- Update to latest Zig build:
```
$ nix flake update
```
This modifies `flake.lock` (Nix package-lock.json equivalent).
2. Update to [Zig v0.11 build API](https://devlog.hexops.com/2023/zig-0-11-breaking-build-changes/)
3. Catch up with other Zig changes and Mach API
4. Removed aarch64 build
I plan to add it back later.

PS: I really like your code - I find it readable + the occasional comment here and there is also nice 😀